### PR TITLE
Added UpdateHeaderImage Function and Made Title and Subtitle Editable After Initialization

### DIFF
--- a/MBTwitterScroll/MBTwitterScroll.h
+++ b/MBTwitterScroll/MBTwitterScroll.h
@@ -27,7 +27,7 @@ typedef enum : NSUInteger {
 
 - (MBTwitterScroll *)initTableViewWithBackgound:(UIImage*)backgroundImage avatarImage:(UIImage *)avatarImage titleString:(NSString *)titleString subtitleString:(NSString *)subtitleString buttonTitle:(NSString *)buttonTitle;
 - (MBTwitterScroll *)initScrollViewWithBackgound:(UIImage*)backgroundImage avatarImage:(UIImage *)avatarImage titleString:(NSString *)titleString subtitleString:(NSString *)subtitleString buttonTitle:(NSString *)buttonTitle contentHeight:(CGFloat)height;
-
+-(void)updateHeaderImage:(UIImage*)newImage;
 
 @property (strong, nonatomic) UIImageView *avatarImage;
 @property (strong, nonatomic) UIView *header;
@@ -36,6 +36,8 @@ typedef enum : NSUInteger {
 @property (strong, nonatomic) UITableView *tableView;
 @property (strong, nonatomic) UIImageView *headerImageView;
 @property (strong, nonatomic) UIButton *headerButton;
+@property (strong, nonatomic) UILabel *subtitleLabel;
+@property (strong, nonatomic) UILabel *titleLabel;
 
 @property (nonatomic, strong) NSMutableArray *blurImages;
 @property (nonatomic,strong) id<MBTwitterScrollDelegate>delegate;

--- a/MBTwitterScroll/MBTwitterScroll.m
+++ b/MBTwitterScroll/MBTwitterScroll.m
@@ -22,7 +22,7 @@ CGFloat const distance_W_LabelHeader = 35.0;
     CGRect bounds = [[UIScreen mainScreen] bounds];
     self = [[MBTwitterScroll alloc] initWithFrame:bounds];
     [self setupView:backgroundImage avatarImage:avatarImage titleString:titleString subtitleString:subtitleString buttonTitle:buttonTitle scrollHeight:height type:MBScroll];
-        
+    
     return self;
 }
 
@@ -75,7 +75,7 @@ CGFloat const distance_W_LabelHeader = 35.0;
         self.scrollView.contentSize = newSize;
         self.scrollView.delegate = self;
     }
-  
+    
     
     self.avatarImage = [[UIImageView alloc] initWithFrame:CGRectMake(10, 79, 69, 69)];
     self.avatarImage.image = avatarImage;
@@ -84,13 +84,13 @@ CGFloat const distance_W_LabelHeader = 35.0;
     self.avatarImage.layer.borderColor = [UIColor whiteColor].CGColor;
     self.avatarImage.clipsToBounds = YES;
     
-    UILabel * titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 156, 250, 25)];
-    titleLabel.text = titleString;
+    self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 156, 250, 25)];
+    self.titleLabel.text = titleString;
     
-    UILabel * subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 177, 250, 25)];
-    subtitleLabel.text = subtitleString;
-    subtitleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:12];
-    subtitleLabel.textColor = [UIColor lightGrayColor];
+    self.subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 177, 250, 25)];
+    self.subtitleLabel.text = subtitleString;
+    self.subtitleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:12];
+    self.subtitleLabel.textColor = [UIColor lightGrayColor];
     
     UIButton * headerButton;
     if (buttonTitle.length > 0) {
@@ -106,15 +106,15 @@ CGFloat const distance_W_LabelHeader = 35.0;
     
     if (type == MBTable) {
         [self.tableView addSubview:self.avatarImage];
-        [self.tableView addSubview:titleLabel];
-        [self.tableView addSubview:subtitleLabel];
+        [self.tableView addSubview:self.titleLabel];
+        [self.tableView addSubview:self.subtitleLabel];
         if (buttonTitle.length > 0) {
             [self.tableView addSubview:headerButton];
         }
     } else {
         [self.scrollView addSubview:self.avatarImage];
-        [self.scrollView addSubview:titleLabel];
-        [self.scrollView addSubview:subtitleLabel];
+        [self.scrollView addSubview:self.titleLabel];
+        [self.scrollView addSubview:self.subtitleLabel];
         if (buttonTitle.length > 0) {
             [self.scrollView addSubview:headerButton];
         }
@@ -215,7 +215,7 @@ CGFloat const distance_W_LabelHeader = 35.0;
     
     
 }
-        
+
 
 
 - (void)prepareForBlurImages
@@ -245,9 +245,11 @@ CGFloat const distance_W_LabelHeader = 35.0;
 }
 
 
+
 - (void) recievedMBTwitterScrollButtonClicked {
     [self.delegate recievedMBTwitterScrollButtonClicked];
 }
+
 
 
 - (void) recievedMBTwitterScrollEvent {
@@ -255,7 +257,17 @@ CGFloat const distance_W_LabelHeader = 35.0;
 }
 
 
+// Function to blur the header image (used if the header image is replaced with updateHeaderImage)
+-(void)resetBlurImages {
+    [self.blurImages removeAllObjects];
+    [self prepareForBlurImages];
+}
 
 
+// Function to update the header image and blur it out appropriately
+-(void)updateHeaderImage:(UIImage*)newImage {
+    self.headerImageView.image = newImage;
+    [self resetBlurImages];
+}
 
 @end

--- a/MBTwitterScrollDemo/MBTwitterScroll/MBTwitterScroll.h
+++ b/MBTwitterScrollDemo/MBTwitterScroll/MBTwitterScroll.h
@@ -27,7 +27,7 @@ typedef enum : NSUInteger {
 
 - (MBTwitterScroll *)initTableViewWithBackgound:(UIImage*)backgroundImage avatarImage:(UIImage *)avatarImage titleString:(NSString *)titleString subtitleString:(NSString *)subtitleString buttonTitle:(NSString *)buttonTitle;
 - (MBTwitterScroll *)initScrollViewWithBackgound:(UIImage*)backgroundImage avatarImage:(UIImage *)avatarImage titleString:(NSString *)titleString subtitleString:(NSString *)subtitleString buttonTitle:(NSString *)buttonTitle contentHeight:(CGFloat)height;
-
+-(void)updateHeaderImage:(UIImage*)newImage;
 
 @property (strong, nonatomic) UIImageView *avatarImage;
 @property (strong, nonatomic) UIView *header;
@@ -36,6 +36,8 @@ typedef enum : NSUInteger {
 @property (strong, nonatomic) UITableView *tableView;
 @property (strong, nonatomic) UIImageView *headerImageView;
 @property (strong, nonatomic) UIButton *headerButton;
+@property (strong, nonatomic) UILabel *subtitleLabel;
+@property (strong, nonatomic) UILabel *titleLabel;
 
 @property (nonatomic, strong) NSMutableArray *blurImages;
 @property (nonatomic,strong) id<MBTwitterScrollDelegate>delegate;

--- a/MBTwitterScrollDemo/MBTwitterScroll/MBTwitterScroll.m
+++ b/MBTwitterScrollDemo/MBTwitterScroll/MBTwitterScroll.m
@@ -22,7 +22,7 @@ CGFloat const distance_W_LabelHeader = 35.0;
     CGRect bounds = [[UIScreen mainScreen] bounds];
     self = [[MBTwitterScroll alloc] initWithFrame:bounds];
     [self setupView:backgroundImage avatarImage:avatarImage titleString:titleString subtitleString:subtitleString buttonTitle:buttonTitle scrollHeight:height type:MBScroll];
-        
+    
     return self;
 }
 
@@ -75,7 +75,7 @@ CGFloat const distance_W_LabelHeader = 35.0;
         self.scrollView.contentSize = newSize;
         self.scrollView.delegate = self;
     }
-  
+    
     
     self.avatarImage = [[UIImageView alloc] initWithFrame:CGRectMake(10, 79, 69, 69)];
     self.avatarImage.image = avatarImage;
@@ -84,38 +84,39 @@ CGFloat const distance_W_LabelHeader = 35.0;
     self.avatarImage.layer.borderColor = [UIColor whiteColor].CGColor;
     self.avatarImage.clipsToBounds = YES;
     
-    UILabel * titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 156, 250, 25)];
-    titleLabel.text = titleString;
+    self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 156, 250, 25)];
+    self.titleLabel.text = titleString;
     
-    UILabel * subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 177, 250, 25)];
-    subtitleLabel.text = subtitleString;
-    subtitleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:12];
-    subtitleLabel.textColor = [UIColor lightGrayColor];
+    self.subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 177, 250, 25)];
+    self.subtitleLabel.text = subtitleString;
+    self.subtitleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:12];
+    self.subtitleLabel.textColor = [UIColor lightGrayColor];
     
+    UIButton * headerButton;
     if (buttonTitle.length > 0) {
-        self.headerButton = [[UIButton alloc] initWithFrame:CGRectMake(self.frame.size.width - 100, 120, 80, 35)];
-        [self.headerButton setTitle:buttonTitle forState:UIControlStateNormal];
-        [self.headerButton setTitleColor:[UIColor lightGrayColor] forState:UIControlStateNormal];
-        self.headerButton.titleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:12];
-        self.headerButton.layer.borderColor = [UIColor lightGrayColor].CGColor;
-        self.headerButton.layer.borderWidth = 1;
-        self.headerButton.layer.cornerRadius = 8;
-        [self.headerButton addTarget:self action:@selector(recievedMBTwitterScrollButtonClicked) forControlEvents:UIControlEventTouchUpInside];
+        headerButton = [[UIButton alloc] initWithFrame:CGRectMake(self.frame.size.width - 100, 120, 80, 35)];
+        [headerButton setTitle:buttonTitle forState:UIControlStateNormal];
+        [headerButton setTitleColor:[UIColor lightGrayColor] forState:UIControlStateNormal];
+        headerButton.titleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:12];
+        headerButton.layer.borderColor = [UIColor lightGrayColor].CGColor;
+        headerButton.layer.borderWidth = 1;
+        headerButton.layer.cornerRadius = 8;
+        [headerButton addTarget:self action:@selector(recievedMBTwitterScrollButtonClicked) forControlEvents:UIControlEventTouchUpInside];
     }
     
     if (type == MBTable) {
         [self.tableView addSubview:self.avatarImage];
-        [self.tableView addSubview:titleLabel];
-        [self.tableView addSubview:subtitleLabel];
+        [self.tableView addSubview:self.titleLabel];
+        [self.tableView addSubview:self.subtitleLabel];
         if (buttonTitle.length > 0) {
-            [self.tableView addSubview:self.headerButton];
+            [self.tableView addSubview:headerButton];
         }
     } else {
         [self.scrollView addSubview:self.avatarImage];
-        [self.scrollView addSubview:titleLabel];
-        [self.scrollView addSubview:subtitleLabel];
+        [self.scrollView addSubview:self.titleLabel];
+        [self.scrollView addSubview:self.subtitleLabel];
         if (buttonTitle.length > 0) {
-            [self.scrollView addSubview:self.headerButton];
+            [self.scrollView addSubview:headerButton];
         }
     }
     
@@ -214,7 +215,7 @@ CGFloat const distance_W_LabelHeader = 35.0;
     
     
 }
-        
+
 
 
 - (void)prepareForBlurImages
@@ -244,9 +245,11 @@ CGFloat const distance_W_LabelHeader = 35.0;
 }
 
 
+
 - (void) recievedMBTwitterScrollButtonClicked {
     [self.delegate recievedMBTwitterScrollButtonClicked];
 }
+
 
 
 - (void) recievedMBTwitterScrollEvent {
@@ -254,7 +257,17 @@ CGFloat const distance_W_LabelHeader = 35.0;
 }
 
 
+// Function to blur the header image (used if the header image is replaced with updateHeaderImage)
+-(void)resetBlurImages {
+    [self.blurImages removeAllObjects];
+    [self prepareForBlurImages];
+}
 
 
+// Function to update the header image and blur it out appropriately
+-(void)updateHeaderImage:(UIImage*)newImage {
+    self.headerImageView.image = newImage;
+    [self resetBlurImages];
+}
 
 @end


### PR DESCRIPTION
As part of the app I have been working on, I needed to be able to make modifications to the MBTwitterScroll after initialization.  Part of the problem I had was not being able to modify the Username / Title and the Bio / Subtitle.  Also, changing the header image after initialization did not have a way to also blur the image automatically, so I added this myself.

The two changes I made were to make titleLabel and subtitleLabel public members so the user could modify them after initialization and to create a publicly accessible updateHeaderImage function that takes a UIImage as a parameter and replaces the header and blurs it automatically just like the MBTwitterScroll does on initialization.

I also updated the files being used by MBTwitterScrollDemo for consistency.

Figured someone else might fine this useful.
